### PR TITLE
Support array children

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -14,7 +14,17 @@ export default function stringify(name, attrs, stack) {
 	// Sortof component support!
 	if (typeof name==='function') {
 		attrs.children = stack.reverse();
-		return String(name(attrs));
+		let resolved = name(attrs);
+		if (Array.isArray(resolved)) {
+			let allSanitized = true;
+			resolved = resolved.map(element => {
+				let elementString = String(element);
+				allSanitized = allSanitized && sanitized[elementString];
+				return elementString;
+			}).join('');
+			sanitized[resolved] = allSanitized;
+		}
+		return String(resolved);
 	}
 
 	let s = `<${name}`;

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -165,4 +165,19 @@ describe('vhtml', () => {
 			'<div class="my-class" for="id"></div>'
 		);
 	});
+
+	it('should support arrays of children', () => {
+		const List = props => {
+			return [
+				<div>First</div>,
+				<div>Second</div>
+			];
+		};
+
+		expect(
+			<List />
+		).to.equal(
+			'<div>First</div><div>Second</div>'
+		);
+	});
 });


### PR DESCRIPTION
React is moving to support this (discussion here: [facebook/react#2127](https://github.com/facebook/react/issues/2127), coming in Fiber). Pretty easy win for a pure JSX renderer.

Adds 56 bytes, 603 B to 659 B