### PR TITLE
Support unsafe html

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -10,11 +10,18 @@ let DOMAttributeNames = {
 
 let sanitized = {};
 
-export default function stringify(name, attrs, stack) {
+export default function stringify(name, attrs, stack, unsafe) {
 	// Sortof component support!
 	if (typeof name==='function') {
 		attrs.children = stack.reverse();
 		return String(name(attrs));
+	}
+
+	let unsafeChild;
+
+	if (stack && unsafe) {
+		unsafeChild = stack[0];
+		sanitized[unsafeChild] = true;
 	}
 
 	let s = `<${name}`;
@@ -45,6 +52,7 @@ export default function stringify(name, attrs, stack) {
 		s += '>';
 	}
 
+	sanitized[unsafeChild] = false;
 	sanitized[s] = true;
 	return s;
 }

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -1,4 +1,5 @@
 import h from '../src/vhtml';
+import stringify from '../src/stringify';
 import { expect } from 'chai';
 /** @jsx h */
 /*global describe,it*/
@@ -163,6 +164,20 @@ describe('vhtml', () => {
 			<div className="my-class" htmlFor="id" />
 		).to.equal(
 			'<div class="my-class" for="id"></div>'
+		);
+	});
+
+	it('should support unsafe html', () => {
+		expect(
+			stringify('div', {}, ['<span>test</span>'], false)
+		).to.equal(
+			'<div>&lt;span&gt;test&lt;/span&gt;</div>'
+		);
+
+		expect(
+			stringify('div', {}, ['<span>test</span>'], true)
+		).to.equal(
+			'<div><span>test</span></div>'
 		);
 	});
 });


### PR DESCRIPTION
Used by dangerouslySetInnerHTML. Marks single child element as safe, then clears the safe mark after rendering.

Adds 30 bytes, 603 B to 633 B